### PR TITLE
Analyze autosell module button functionality

### DIFF
--- a/ckvb9wuefh9831
+++ b/ckvb9wuefh9831
@@ -1445,6 +1445,7 @@ local autofarmFlipConnections = {}
 local continuousFlipConnection = nil
 local renderSteppedConnection = nil
 local isMapLoaded = false
+local gameStartTime = tick() -- Время запуска скрипта для определения прогрузки
 
 -- ПРОСТАЯ функция для постоянного переворота персонажа
 local function startContinuousFlip()
@@ -1651,12 +1652,36 @@ local function monitorAutofarmState()
             
             -- Проверяем завершена ли прогрузка карты
             if not isMapLoaded then
-                -- Ищем сообщение о завершении прогрузки в логах
-                -- Можно проверить через глобальные переменные или другие методы
-                if _G.mapLoadCompleted or 
-                   (_G.AutofarmConfig and _G.AutofarmConfig.mapLoaded) then
+                -- Множественные способы определения прогрузки карты
+                local mapLoadIndicators = {
+                    -- Стандартные глобальные переменные
+                    _G.mapLoadCompleted,
+                    _G.AutofarmConfig and _G.AutofarmConfig.mapLoaded,
+                    
+                    -- Проверка через рабочее пространство
+                    workspace.CurrentCamera and workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable,
+                    
+                    -- Проверка загрузки игрока
+                    Players.LocalPlayer and Players.LocalPlayer.Character and 
+                    Players.LocalPlayer.Character:FindFirstChild("Humanoid") and
+                    Players.LocalPlayer.Character:FindFirstChild("HumanoidRootPart"),
+                    
+                    -- Проверка, что игра полностью загружена
+                    game:IsLoaded(),
+                    
+                    -- Дополнительная проверка через время (минимум 5 секунд после запуска)
+                    tick() - gameStartTime > 5
+                }
+                
+                -- Если хотя бы несколько индикаторов говорят о загрузке
+                local loadedCount = 0
+                for _, indicator in ipairs(mapLoadIndicators) do
+                    if indicator then loadedCount = loadedCount + 1 end
+                end
+                
+                if loadedCount >= 3 then -- Требуем минимум 3 положительных индикатора
                     isMapLoaded = true
-                    print("🗺️ FLIP: Прогрузка карты завершена!")
+                    print("🗺️ FLIP: Прогрузка карты завершена! (Подтверждено " .. loadedCount .. " индикаторами)")
                 end
             end
             
@@ -1666,34 +1691,72 @@ local function monitorAutofarmState()
                     -- Автофарм включился И карта прогружена - переворачиваем персонажа
                     print("🚀 FLIP: Обнаружен запуск автофарма после прогрузки карты - переворачиваем персонажа!")
                     
-                    -- МГНОВЕННЫЙ тест переворота
-                    local player = Players.LocalPlayer
-                    if player and player.Character then
-                        local humanoidRootPart = player.Character:FindFirstChild("HumanoidRootPart")
-                        if humanoidRootPart then
-                            print("🔄 FLIP: МГНОВЕННЫЙ ТЕСТ - переворачиваем прямо сейчас!")
-                            local pos = humanoidRootPart.Position
-                            humanoidRootPart.CFrame = CFrame.new(pos + Vector3.new(0, -6, 0)) * CFrame.Angles(math.rad(180), 0, 0)
-                            print("🔄 FLIP: ТЕСТ ЗАВЕРШЕН - персонаж должен быть перевернут!")
-                        end
-                    end
-                    
                     task.spawn(function()
-                        task.wait(3) -- Даем больше времени для стабилизации после прогрузки
+                        -- Дополнительная проверка стабильности перед переворотом
+                        local stableChecks = 0
+                        local maxStableChecks = 3
+                        
+                        while stableChecks < maxStableChecks do
+                            task.wait(1)
+                            
+                            -- Проверяем что персонаж стабилен
+                            local player = Players.LocalPlayer
+                            if player and player.Character then
+                                local humanoidRootPart = player.Character:FindFirstChild("HumanoidRootPart")
+                                local humanoid = player.Character:FindFirstChild("Humanoid")
+                                
+                                if humanoidRootPart and humanoid then
+                                    -- Проверяем что персонаж не движется быстро и не в воздухе
+                                    local velocity = humanoidRootPart.AssemblyLinearVelocity or humanoidRootPart.Velocity
+                                    local isStable = velocity.Magnitude < 50 and humanoid.FloorMaterial ~= Enum.Material.Air
+                                    
+                                    if isStable then
+                                        stableChecks = stableChecks + 1
+                                        print("🔄 FLIP: Проверка стабильности " .. stableChecks .. "/" .. maxStableChecks)
+                                    else
+                                        stableChecks = 0 -- Сбрасываем если персонаж нестабилен
+                                        print("🔄 FLIP: Персонаж нестабилен, ждем стабилизации...")
+                                    end
+                                else
+                                    print("🔄 FLIP: Персонаж не найден, ждем...")
+                                    task.wait(2)
+                                end
+                            else
+                                print("🔄 FLIP: Игрок не найден, ждем...")
+                                task.wait(2)
+                            end
+                        end
+                        
+                        print("🔄 FLIP: Персонаж стабилен, выполняем переворот!")
                         flipPlayerUpsideDown()
                     end)
                 elseif isAutofarmCurrentlyEnabled and not isMapLoaded then
                     -- Автофарм включился но карта не прогружена - ждем
                     print("🔄 FLIP: Автофарм включен, но ждем завершения прогрузки карты...")
                     task.spawn(function()
-                        -- Ждем прогрузки карты
+                        -- Ждем прогрузки карты с улучшенной проверкой
                         while isAutofarmCurrentlyEnabled and not isMapLoaded do
                             task.wait(1)
-                            -- Проверяем прогрузку снова
-                            if _G.mapLoadCompleted or 
-                               (_G.AutofarmConfig and _G.AutofarmConfig.mapLoaded) then
+                            -- Используем ту же логику проверки что и в основном цикле
+                            local mapLoadIndicators = {
+                                _G.mapLoadCompleted,
+                                _G.AutofarmConfig and _G.AutofarmConfig.mapLoaded,
+                                workspace.CurrentCamera and workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable,
+                                Players.LocalPlayer and Players.LocalPlayer.Character and 
+                                Players.LocalPlayer.Character:FindFirstChild("Humanoid") and
+                                Players.LocalPlayer.Character:FindFirstChild("HumanoidRootPart"),
+                                game:IsLoaded(),
+                                tick() - gameStartTime > 5
+                            }
+                            
+                            local loadedCount = 0
+                            for _, indicator in ipairs(mapLoadIndicators) do
+                                if indicator then loadedCount = loadedCount + 1 end
+                            end
+                            
+                            if loadedCount >= 3 then
                                 isMapLoaded = true
-                                print("🗺️ FLIP: Прогрузка карты завершена во время ожидания!")
+                                print("🗺️ FLIP: Прогрузка карты завершена во время ожидания! (Подтверждено " .. loadedCount .. " индикаторами)")
                                 break
                             end
                         end


### PR DESCRIPTION
Fix `flip` function to activate only after map load and character stabilization.

The previous implementation would attempt to flip the character immediately upon autofarm activation, leading to issues if the map wasn't fully loaded or the character wasn't stable. This change introduces robust checks for map loading (multiple indicators) and character stability (velocity, on-ground status) before performing the flip, preventing premature activation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c0b3ad9-5fd8-4fa5-b5c1-412e8a151b41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c0b3ad9-5fd8-4fa5-b5c1-412e8a151b41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

