### PR TITLE
Fly to wait point and reset speed

### DIFF
--- a/huyna
+++ b/huyna
@@ -1498,6 +1498,9 @@ print("   _G.AutosellModule.disableAllItems() - отключить ВСЕ пре
 print("🔒 Функции фиксации персонажа:")
 print("   _G.AutosellModule.freezePlayerAtShiftplox() - зафиксировать персонажа у Shiftplox")
 print("   _G.AutosellModule.unfreezePlayerFromShiftplox() - снять фиксацию персонажа")
+print("🗺️ MAP LOAD: Система автоматического полета к точке ожидания после загрузки карты добавлена!")
+print("   ✈️ Координаты точки ожидания: 8, 0, -783")
+print("   🔒 Автоматическая фиксация на 1 секунду для сброса скорости")
 
 
 ensureMovementMonitor = function()
@@ -1628,5 +1631,101 @@ local function initializeTravelMonitor()
 		end
 	end)
 end
+
+-- Функция мониторинга загрузки карты и полета к точке ожидания
+local function initializeMapLoadMonitor()
+	print("🗺️ MAP LOAD: Инициализация мониторинга загрузки карты...")
+	
+	local isMapLoaded = false
+	local hasTraveledAfterLoad = false
+	local gameStartTime = tick()
+	
+	task.spawn(function()
+		while true do
+			task.wait(1)
+			
+			-- Проверяем завершена ли прогрузка карты
+			if not isMapLoaded then
+				-- Множественные способы определения прогрузки карты
+				local mapLoadIndicators = {
+					-- Стандартные глобальные переменные
+					_G.mapLoadCompleted,
+					_G.AutofarmConfig and _G.AutofarmConfig.mapLoaded,
+					
+					-- Проверка через рабочее пространство
+					workspace.CurrentCamera and workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable,
+					
+					-- Проверка загрузки игрока
+					Players.LocalPlayer and Players.LocalPlayer.Character and 
+					Players.LocalPlayer.Character:FindFirstChild("Humanoid") and
+					Players.LocalPlayer.Character:FindFirstChild("HumanoidRootPart"),
+					
+					-- Проверка, что игра полностью загружена
+					game:IsLoaded(),
+					
+					-- Дополнительная проверка через время (минимум 5 секунд после запуска)
+					tick() - gameStartTime > 5
+				}
+				
+				-- Если хотя бы несколько индикаторов говорят о загрузке
+				local loadedCount = 0
+				for _, indicator in ipairs(mapLoadIndicators) do
+					if indicator then loadedCount = loadedCount + 1 end
+				end
+				
+				if loadedCount >= 3 then -- Требуем минимум 3 положительных индикатора
+					isMapLoaded = true
+					print("🗺️ MAP LOAD: Прогрузка карты завершена! (Подтверждено " .. loadedCount .. " индикаторами)")
+					
+					-- Запускаем полет к точке ожидания после загрузки карты
+					if not hasTraveledAfterLoad then
+						hasTraveledAfterLoad = true
+						task.spawn(function()
+							-- Ждем небольшую паузу для стабилизации
+							task.wait(2)
+							print("✈️ MAP LOAD: Запускаем полет к точке ожидания после загрузки карты...")
+							startTravelToSafeSpot()
+							
+							-- Ждем достижения точки ожидания
+							while isTravelActive do
+								task.wait(0.1)
+							end
+							
+							-- Фиксируем персонажа на секунду для сброса скорости
+							print("🔒 MAP LOAD: Фиксируем персонажа на секунду для сброса скорости...")
+							local player = Players.LocalPlayer
+							local character = player and player.Character
+							local hrp = character and character:FindFirstChild("HumanoidRootPart")
+							
+							if hrp then
+								-- Создаем временный BodyVelocity для фиксации
+								local freezeBodyVelocity = Instance.new("BodyVelocity")
+								freezeBodyVelocity.Name = "MapLoadFreezeBodyVelocity"
+								freezeBodyVelocity.MaxForce = Vector3.new(9e9, 9e9, 9e9)
+								freezeBodyVelocity.Velocity = Vector3.new(0, 0, 0)
+								freezeBodyVelocity.Parent = hrp
+								
+								-- Ждем секунду
+								task.wait(1)
+								
+								-- Удаляем фиксацию
+								if freezeBodyVelocity and freezeBodyVelocity.Parent then
+									freezeBodyVelocity:Destroy()
+								end
+								print("✅ MAP LOAD: Фиксация снята, персонаж готов к сканированию предметов!")
+							end
+						end)
+					end
+				end
+			end
+		end
+	end)
+end
+
+-- Запускаем мониторинг загрузки карты
+task.spawn(function()
+	task.wait(1)
+	initializeMapLoadMonitor()
+end)
 
 return _G.AutosellModule


### PR DESCRIPTION
Adds automatic character movement to a waiting point after map load to prepare for item scanning.

After map loading is detected, the character will automatically fly to `8, 0, -783` and pause for 1 second to reset speed, readying for item scanning.

---
<a href="https://cursor.com/background-agent?bcId=bc-89a11095-fd78-4203-ae97-6902c153f45a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89a11095-fd78-4203-ae97-6902c153f45a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

