### PR TITLE
Fly to wait point and reset speed

### DIFF
--- a/huyna
+++ b/huyna
@@ -1479,8 +1479,23 @@ end
 -- FLIP exports removed
 
 task.spawn(function()
-	task.wait(3)
-	initializeTravelMonitor()
+		task.wait(3)
+		initializeTravelMonitor()
+	end)
+
+-- Автоперелёт к точке ожидания после загрузки карты
+task.spawn(function()
+	if not game:IsLoaded() then
+		game.Loaded:Wait()
+	end
+	local player = Players.LocalPlayer
+	local character = player and (player.Character or player.CharacterAdded:Wait())
+	if character then
+		character:WaitForChild("HumanoidRootPart", 10)
+	end
+	-- небольшая стабилизирующая задержка
+	task.wait(0.5)
+	startTravelToSafeSpot()
 end)
 
 print("🤖 AUTOSELL: Модуль загружен успешно! Лимиты предметов обновлены.")
@@ -1594,7 +1609,13 @@ local function startTravelToSafeSpot()
 			travelBodyVelocity.Velocity = dir * dynamicSpeed
 		else
 			travelBodyVelocity.Velocity = Vector3.new(0,0,0)
-			print("✅ TRAVEL: Точка ожидания достигнута")
+			print("✅ TRAVEL: Точка ожидания достигнута, фиксируемся на 1 секунду для сброса скорости")
+			pcall(function()
+				freezePlayerAtShiftplox()
+				task.delay(1.0, function()
+					unfreezePlayerFromShiftplox()
+				end)
+			end)
 			stopTravelToSafeSpot()
 		end
 	end)


### PR DESCRIPTION
Implement auto-flight to a waiting point after map load and a 1-second freeze upon arrival to reset character speed.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ebdbb2d-7951-43a8-828f-0eb21ec9fb84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ebdbb2d-7951-43a8-828f-0eb21ec9fb84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

